### PR TITLE
Upgrade backend to Pydantic v2 for Python 3.12 compatibility

### DIFF
--- a/backend/app/api/v1/endpoints/projectile.py
+++ b/backend/app/api/v1/endpoints/projectile.py
@@ -4,7 +4,7 @@ from math import radians
 from typing import List
 
 from fastapi import APIRouter
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 
 from physics.analytics import projectile_motion
 
@@ -18,7 +18,8 @@ class ProjectileRequest(BaseModel):
     gravity: float = Field(9.80665, gt=0, description="Acceleration due to gravity in m/s^2")
     samples: int = Field(50, ge=2, le=5000)
 
-    @validator("launch_angle")
+    @field_validator("launch_angle")
+    @classmethod
     def validate_angle(cls, value: float) -> float:
         if not 0 <= value <= 180:
             raise ValueError("Launch angle must be between 0 and 180 degrees")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,3 @@
 fastapi==0.110.0
 uvicorn==0.27.1
-pydantic==1.10.14
+pydantic==2.5.3


### PR DESCRIPTION
## Summary
- upgrade the backend dependencies to pydantic 2.5.3 for Python 3.12 support
- update projectile and simulation API schemas to use Pydantic v2 validators and serialization helpers

## Testing
- python -m pytest tests/ -v

------
https://chatgpt.com/codex/tasks/task_e_68cdb534f8048330b3c157ca8c54394e