### PR TITLE
Fix docker compose build context

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,10 @@
 # Docker Compose for local development
-version: '3.8'
-
 services:
   # Backend API service
   physics-api:
-    build: 
-      context: .
+    build:
+      context: ${COMPOSE_PROJECT_DIR:-.}
+      dockerfile: Dockerfile
       target: backend
     ports:
       - "8000:8000"


### PR DESCRIPTION
## Summary
- remove the deprecated `version` declaration from the compose file to silence warnings
- point the backend build context at `${COMPOSE_PROJECT_DIR:-.}` and explicitly set the Dockerfile so compose can locate it even when invoked from another directory

## Testing
- not run (docker not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cdb8d09a94833096a4ae6bf77ab1a6